### PR TITLE
Set local-storage as the default storage class

### DIFF
--- a/samples/features/azure-arc/deployment/kubeadm/ubuntu-single-node-vm/setup-controller.sh
+++ b/samples/features/azure-arc/deployment/kubeadm/ubuntu-single-node-vm/setup-controller.sh
@@ -239,6 +239,10 @@ kubectl taint nodes ${master_node} node-role.kubernetes.io/master:NoSchedule-
 #
 kubectl apply -f https://raw.githubusercontent.com/microsoft/sql-server-samples/master/samples/features/azure-arc/deployment/kubeadm/ubuntu/local-storage-provisioner.yaml
 
+# Set local-storage as the default storage class
+#
+kubectl patch storageclass local-storage -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
 # Install the software defined network.
 #
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml


### PR DESCRIPTION
Kubeadm does not come with any storage classes by default.  The one we create (local-storage) will be the only one, so it should be the default.  This way users don't need to provide "--dataClass local-storage --metadataStorageClass local-storage" when creating Postgres.